### PR TITLE
tp->advmss must not be zero, otherwise the kernel maybe crash.

### DIFF
--- a/forge_socket.c
+++ b/forge_socket.c
@@ -233,6 +233,9 @@ int forge_setsockopt(struct sock *sk, int level, int optname,
 		if (tp->rx_opt.user_mss && tp->rx_opt.user_mss < tp->advmss)
 			tp->advmss = tp->rx_opt.user_mss;
 
+		if (tp->advmss == 0)
+			tp->advmss = st.mss_clamp;
+
 		/* from inet_csk_forge: */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 33)
 		inet_sk(sk)->dport = st.dport;


### PR DESCRIPTION
if tp->advmss is zero, the kernel maybe crashed by dividing zero. 
==============================================================
Crash Stack.
PID: 2817   TASK: ffff95965ce44f10  CPU: 1   COMMAND: "xxxxxxx"
 #0 [ffff9592f55cb5e0] machine_kexec at ffffffffaa460afa
 #1 [ffff9592f55cb640] __crash_kexec at ffffffffaa513402
 #2 [ffff9592f55cb710] crash_kexec at ffffffffaa5134f0
 #3 [ffff9592f55cb728] oops_end at ffffffffaab17738
 #4 [ffff9592f55cb750] die at ffffffffaa42e96b
 #5 [ffff9592f55cb780] do_trap at ffffffffaab16eb0
 #6 [ffff9592f55cb7d0] do_divide_error at ffffffffaa42b08e
 #7 [ffff9592f55cb880] divide_error at ffffffffaab22a5e
    [exception RIP: tcp_event_data_recv+216]
    RIP: ffffffffaaa465c8  RSP: ffff9592f55cb938  RFLAGS: 00010246
    RAX: 0000000000001000  RBX: ffff9595fbf18000  RCX: 0000000000000000
    RDX: 0000000000000000  RSI: ffff9592f5688000  RDI: ffffffffab0fc900
    RBP: ffff9592f55cb950   R8: 0000000000000000   R9: ffffffffaaca68c0
    R10: 0000000000000014  R11: 0000000000000000  R12: ffff95965b6e0000
    R13: 0000000100102bb2  R14: ffff95965b6e0000  R15: ffff95965b6ca04c
    ORIG_RAX: ffffffffffffffff  CS: 0010  SS: 0018
 #8 [ffff9592f55cb958] tcp_data_queue at ffffffffaaa49193
Kernel Version: 3.10.0-862.2.3.el7.x86_64