### PR TITLE
accomodate changes and deprecations for forgesocket in 22.04

### DIFF
--- a/forge_socket.c
+++ b/forge_socket.c
@@ -403,7 +403,9 @@ int forge_setsockopt(struct sock *sk, int level, int optname,
 		inet_ehash_nolisten(sk, NULL);
 #else
 		// https://www.spinics.net/lists/kernel/msg4334811.html
-		inet_ehash_nolisten(sk, NULL, false);
+		// bool inet_ehash_nolisten(struct sock *sk, struct sock *osk,
+		// 	 bool *found_dup_sk);
+		inet_ehash_nolisten(sk, NULL, NULL);
 #endif
 
 		/* uc_ttl is at least as old as 2.6.17, maybe older.

--- a/forge_socket.h
+++ b/forge_socket.h
@@ -40,8 +40,13 @@ struct tcp_state {
 
 
 #ifdef __KERNEL__
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
 int forge_setsockopt(struct sock *sk, int level, int optname,
 		char __user *optval, unsigned int optlen);
+#else
+int forge_setsockopt(struct sock *sk, int level, int optname,
+		sockptr_t optval, unsigned int optlen);
+#endif
 int forge_getsockopt(struct sock *sk, int level, int optname,
 		char __user *optval, int __user *optlen);
 int forge_getsockopt_socket(struct socket *sock, int level, int optname,


### PR DESCRIPTION
Changes have been made to the Linux kernel effecting several things in the forgesocket module. I believe this fix is a backward compatible way of handling those changes and deprecations. 

* `get_seconds()` deprecated because of cast to u32 in favor of `ktime_get_real_seconds()`
  * cutting at 4.3.0 because `ktime_get_real_seconds()` has been available for a while.
* `tcp_setsockopt(...)` function signature changed @5.9.0 to use new `sockptr_t` type in place of `char __user *optval`
* `inet_ehash_nolisten(...)` function signature changed @5.4.191 to [prevent tcp race when using syncookies](https://www.spinics.net/lists/kernel/msg4334811.html)
  * hard code `false` because we are not dealing with syn cookies or any race conditions related.

These changes are compiling successfully on: 
- 5.15.0-43-generic (ubuntu 22.04)
- 4.4.0-137-generic (ubuntu 16.04)
- 5.4.0-77-generic (ubuntu 20.04)
- 5.4.0-124-generic (ubuntu 20.04 latest stable as of 08/12/22)